### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The orignal code comes from [Booyah Inc](https://github.com/booyah/protobuf-objc
 ## Supported Platform
 
 * iOS 4.0 and above
-* XCode 4 and above
+* Xcode 4 and above
 
 
 ## Features


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
